### PR TITLE
修改: postcss.config.js 編輯器被過濾 bug (#240)

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,47 +1,35 @@
-module.exports = {
+let environment = {
   plugins: [
+    require('tailwindcss')("tailwind.config.js"),
+    require('autoprefixer'),
     require('postcss-import'),
     require('postcss-flexbugs-fixes'),
-    require('tailwindcss'),
-    require('autoprefixer'),
     require('postcss-preset-env')({
       autoprefixer: {
         flexbox: 'no-2009'
       },
       stage: 3
-    })
+    }),
   ]
 }
 
-// 今天 demo 完會再做處理
-// let environment = {
-//   plugins: [
-//     require('tailwindcss'),
-//     require('autoprefixer'),
-//     require('postcss-import'),
-//     require('postcss-flexbugs-fixes'),
-//     require('postcss-preset-env')({
-//       autoprefixer: {
-//         flexbox: 'no-2009'
-//       },
-//       stage: 3
-//     }),
-//   ]
-// }
+if (process.env.RAILS_ENV === "production") {
+  environment.plugins.push(
+    require('@fullhuman/postcss-purgecss')({
+      content: [
+        './app/**/*.html.erb',
+        './app/helpers/**/*.rb',
+        './app/javascript/**/*.js',
+        './app/javascript/**/*.scss',
+        './app/javascript/**/*.jsx',
+        './node_modules/codemirror/**/**/*.css',
+        './node_modules/codemirror/**/**/*.js',
+        './node_modules/@uiw/react-md-editor/**/**/*.js',
+        './node_modules/@uiw/react-md-editor/**/**/*.css'
+      ],
+      defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || [],
+    })
+  )
+}
 
-// if (process.env.RAILS_ENV === "production") {
-//   environment.plugins.push(
-//     require('@fullhuman/postcss-purgecss')({
-//       content: [
-//         './app/**/**/*.html.erb',
-//         './app/**/**/*.rb',
-//         './app/**/**/*.js',
-//         './app/**/**/*.scss',
-//         './app/**/**/*.jsx',
-//       ],
-//       defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || []
-//     })
-//   )
-// }
-
-// module.exports = environment
+module.exports = environment

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,7 @@
 module.exports = {
-  purge: [],
+  purge: {
+    content: []
+  },
   darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {
@@ -18,5 +20,4 @@ module.exports = {
   variants: {
     extend: {},
   },
-  plugins: [],
 };


### PR DESCRIPTION
1. 原本的寫法會將解題區的編輯器 `codemirror` 及討論區新增文章的 MD 編輯器過濾掉，調整寫法將他們包回來
2. 註解掉判斷式可在本地端做測試，先執行 `$bin/webpack` 再將判斷式註解掉重新執行 `$bin/webpack` 看使用前後差異
